### PR TITLE
fix(semantic-prs): check only PR title

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+titleOnly: true
+targetUrl: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format


### PR DESCRIPTION
Add configuration for semantic-prs app to check only the PR title and not commits. Also add documentation for help regarding commit message format.