### PR TITLE
fix(sdk_update): encode release notes in the payload

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -60,7 +60,7 @@ jobs:
           PAYLOAD=$(node -pe "JSON.stringify({
             version: '${{ steps.semantic.outputs.release-version }}',
             sha: '${{ github.sha }}',
-            release_notes: '${{ steps.semantic.outputs.release-notes }}'.replace(/\n/g, '\\\\n'),
+            release_notes: Buffer.from('${{ steps.semantic.outputs.release-notes }}').toString('base64'),
             release_type: '${{ steps.semantic.outputs.release-type }}'
           })")
 


### PR DESCRIPTION
Some unexpected characters as '#' caused the workflow to fail before. Encoding the release notes to avoid this problem. On streaming view workflow we will decode it to have information on what changed in the new version in the streaming-games repo as well for more transparency.