### PR TITLE
fix(release): change order of semantic release plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,18 +32,19 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json"
-          ]
-        }
-      ],
-      [
         "@semantic-release/npm",
         {
           "tarballDir": ".github",
           "pkgRoot": "build"
+        }
+      ],
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "package.json",
+            "src/controllers/build-info.json"
+          ]
         }
       ],
       [


### PR DESCRIPTION
To fix the automated chore(release) commit to step versions, also added the src/controllers/build-info.json to the files that need to be commited by the semantic-release bot